### PR TITLE
Extract audio as MP3

### DIFF
--- a/class/Downloader.php
+++ b/class/Downloader.php
@@ -197,7 +197,7 @@ class Downloader
 
 		if($this->audio_only)
 		{
-			$cmd .= " -x ";
+			$cmd .= " -x --audio-format mp3 ";
 		}
 
 		foreach($this->urls as $url)


### PR DESCRIPTION
By default the output is .opus, which is not widely readable music format I think.